### PR TITLE
Handle scenarios where self.labels is empty or contains multiple items.

### DIFF
--- a/src/agents/tools/data_extraction.py
+++ b/src/agents/tools/data_extraction.py
@@ -45,7 +45,7 @@ class JiraDataExtraction(BaseTool):
 
     def __get_issues_count(self):
         """Get the total issues in the project with a given label"""
-        jql_query = ' AND '.join(f'labels = "{label}"' for label in self.labels)
+        jql_query = ' OR '.join(f'labels = "{label}"' for label in self.labels)
 
         params = {
             "jql": jql_query,
@@ -68,8 +68,10 @@ class JiraDataExtraction(BaseTool):
 
     def __get_labeled_issues(self, start_at=0, max_results=50):
         """Get issues with specified labels in a given project using JQL search"""
-        labels_query = " AND ".join([f'labels = "{label}"' for label in self.labels])
-        jql_query = f'project = {self.project_id} AND {labels_query}'
+        jql_query = f'project = {self.project_id}'
+        labels_query = " OR ".join([f'labels = "{label}"' for label in self.labels])
+        if len(labels_query) > 0:
+            jql_query = f'project = {self.project_id} AND ({labels_query})'
 
         params = {
             "jql": jql_query,


### PR DESCRIPTION
when self.labels is empty, the constructed jql has syntax error. when self.labels contains multiple items, the search result will be empty if using 'AND" ( should be "OR" )